### PR TITLE
Handle permissions on mac

### DIFF
--- a/include/ae-zoom.h
+++ b/include/ae-zoom.h
@@ -69,6 +69,7 @@ enum class ZOOM_STATUS
 {
 	INITIALIZATION_ERROR,
 	INITIALIZED,
+	FINISHED
 };
 
 class KeyCodes 

--- a/include/ae-zoom.h
+++ b/include/ae-zoom.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include <mutex>
-#include <thread>
+#include <atomic>
+#include <future>
 #include <string>
 #include <vector>
 #include <optional>
@@ -37,21 +38,18 @@ constexpr char SETTINGS_SECTION_NAME[] = "Quis/Ae_Smooth_Zoom";
 extern "C" DllExport AEGP_PluginInitFuncPrototype EntryPointFunc;
 
 class LogMessage {
-private:
-	std::string format_str;
 public:
 	unsigned int level = 0;
-	const char* format = nullptr;
+	std::string format_str;
+	std::string instructions_str;
 
-	LogMessage(unsigned int level, const char* format)
-		: level(level), format(format)
+	LogMessage(
+		unsigned int level, 
+		const std::string& _format_str, 
+		const std::string& _instructions_str
+	)
+		: level(level), format_str(_format_str), instructions_str(_instructions_str)
 	{}
-
-	LogMessage(unsigned int level, const std::string& _format_str)
-		: format_str(_format_str), level(level) 
-	{
-		format = format_str.c_str();
-	}
 };
 
 enum class WIND_RECT
@@ -65,6 +63,12 @@ enum class KB_ACTION
 	INCREASE,
 	DECREASE,
 	SET_TO
+};
+
+enum class ZOOM_STATUS
+{
+	INITIALIZATION_ERROR,
+	INITIALIZED,
 };
 
 class KeyCodes 

--- a/src/ae-zoom.cpp
+++ b/src/ae-zoom.cpp
@@ -436,7 +436,7 @@ std::tuple<std::string, std::string> GetHookErrorStrings(int status)
         case UIOHOOK_ERROR_AXAPI_DISABLED:
 			result = {
 				"Failed to enable access for assistive devices.", 
-				"Zoom plug-in requires accessibility permissions to detect key bindings. Enable the permissions in System Settins -> Accessibility -> Adobe After Effects."
+				"Zoom plug-in requires accessibility permissions to detect key bindings. Enable the permissions in System Settings -> Privacy & Security -> Accessibility -> Adobe After Effects."
 			};
             break;
 
@@ -697,8 +697,18 @@ static void FillZoomStatusForScript(TaggedData* retval)
 
 	if (zoom_status)
 	{
+		auto iohook_status = WaitForFuture(S_iohook_future, std::chrono::seconds(0));
+
 		retval->type = kTypeInteger;
-		retval->data.intval = static_cast<long>(zoom_status.value());
+
+		if (iohook_status && iohook_status.value() == UIOHOOK_SUCCESS)
+		{
+			retval->data.intval = static_cast<long>(ZOOM_STATUS::FINISHED);
+		}
+		else
+		{
+			retval->data.intval = static_cast<long>(zoom_status.value());
+		}
 	}
 }
 


### PR DESCRIPTION
Handle cases when After Effects on macOS doesn't have accessibility permissions enabled on plug-in first load. Now, if there's an error during hook start, the script panel can receive the error message and the plug-in can be reloaded.